### PR TITLE
Add admin test send page and API

### DIFF
--- a/app/api/admin/test-send/route.ts
+++ b/app/api/admin/test-send/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createClient } from "@supabase/supabase-js";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+const EMAILJS_ENDPOINT = "https://api.emailjs.com/api/v1.0/email/send";
+
+export async function POST(req: NextRequest) {
+  const adm = cookies().get("adm")?.value;
+  if (!adm || adm !== process.env.ADMIN_TOKEN) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const checkout_id = String(body?.checkout_id || "");
+  const email = String(body?.email || "");
+  const name = String(body?.name || "");
+  const product_name = String(body?.product_name || "Seu produto");
+  const checkout_url = String(body?.checkout_url || "");
+
+  if (!checkout_id || !email || !checkout_url) {
+    return NextResponse.json({ error: "Campos obrigatórios faltando" }, { status: 400 });
+  }
+
+  // idempotência manual: se já houver, não envia de novo
+  const { data: exists } = await supabase
+    .from("abandoned_emails")
+    .select("id")
+    .eq("checkout_id", checkout_id)
+    .maybeSingle();
+  if (exists) {
+    return NextResponse.json({ ok: true, alreadySent: true });
+  }
+
+  const discount_code = process.env.DEFAULT_DISCOUNT_CODE || "";
+  const expire_hours = process.env.DEFAULT_EXPIRE_HOURS || "24";
+  const unsubscribe_url = "https://romeikebeauty.example/unsubscribe";
+
+  const template_params = {
+    name,
+    product_name,
+    checkout_url,
+    discount_code,
+    expire_hours,
+    unsubscribe_url,
+  };
+
+  // Enviar via EmailJS
+  const res = await fetch(EMAILJS_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      service_id: process.env.EMAILJS_SERVICE_ID,
+      template_id: process.env.EMAILJS_TEMPLATE_ID,
+      user_id: process.env.EMAILJS_PUBLIC_KEY,
+      template_params,
+    }),
+  });
+
+  if (!res.ok) {
+    const err = await res.text();
+    return NextResponse.json({ error: "EmailJS fail", details: err }, { status: 500 });
+  }
+
+  // Gravar no Supabase
+  await supabase.from("abandoned_emails").insert({
+    checkout_id,
+    email,
+    product_name,
+    checkout_url,
+    payload: {
+      lead: { email, name },
+      product: { name: product_name },
+      from: "admin-test"
+    }
+  });
+
+  return NextResponse.json({ ok: true, sent: true });
+}

--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -1,0 +1,20 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import TestForm from "../../components/TestForm";
+
+export const dynamic = "force-dynamic";
+
+export default function TestPage() {
+  const adm = cookies().get("adm")?.value;
+  if (!adm || adm !== process.env.ADMIN_TOKEN) redirect("/login");
+
+  return (
+    <main className="mx-auto max-w-lg p-6">
+      <h1 className="mb-4 text-2xl font-bold">Teste de Envio (Abandono)</h1>
+      <p className="mb-4 text-sm text-neutral-600">
+        Preencha seu e-mail e clique em <b>Enviar teste</b>. Isso simula um carrinho abandonado e envia 1 e-mail.
+      </p>
+      <TestForm />
+    </main>
+  );
+}

--- a/components/TestForm.tsx
+++ b/components/TestForm.tsx
@@ -1,0 +1,101 @@
+"use client";
+import { useState } from "react";
+
+export default function TestForm() {
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("Cliente Teste");
+  const [product, setProduct] = useState("Catálogo Editável - Cílios");
+  const [checkoutUrl, setCheckoutUrl] = useState("https://pay.kiwify.com.br/SEU_LINK");
+  const [status, setStatus] = useState<string | null>(null);
+
+  function randomId() {
+    // ck_ + 16 chars
+    const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    let s = "ck_";
+    for (let i = 0; i < 16; i++) s += chars[Math.floor(Math.random() * chars.length)];
+    return s;
+  }
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setStatus("Enviando...");
+
+    const checkout_id = randomId();
+    try {
+      const res = await fetch("/api/admin/test-send", {
+        method: "POST",
+        body: JSON.stringify({
+          checkout_id,
+          email,
+          name,
+          product_name: product,
+          checkout_url: checkoutUrl
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setStatus(`OK: enviado (checkout_id: ${checkout_id})`);
+      } else {
+        setStatus(`Erro: ${data?.error || "desconhecido"}`);
+      }
+    } catch (err: any) {
+      setStatus(`Erro de rede: ${err?.message || err}`);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-3">
+      <div>
+        <label className="block text-sm mb-1">Seu e-mail</label>
+        <input
+          required
+          type="email"
+          className="w-full rounded-lg border p-2"
+          placeholder="voce@exemplo.com"
+          value={email}
+          onChange={(e)=>setEmail(e.target.value)}
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm mb-1">Nome</label>
+        <input
+          type="text"
+          className="w-full rounded-lg border p-2"
+          value={name}
+          onChange={(e)=>setName(e.target.value)}
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm mb-1">Produto</label>
+        <input
+          type="text"
+          className="w-full rounded-lg border p-2"
+          value={product}
+          onChange={(e)=>setProduct(e.target.value)}
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm mb-1">Checkout URL</label>
+        <input
+          type="url"
+          className="w-full rounded-lg border p-2"
+          value={checkoutUrl}
+          onChange={(e)=>setCheckoutUrl(e.target.value)}
+        />
+      </div>
+
+      <button
+        type="submit"
+        className="w-full rounded-lg border px-3 py-2 font-medium"
+      >
+        Enviar teste
+      </button>
+
+      {status && <p className="text-sm text-neutral-700">{status}</p>}
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add an admin-protected test page that renders the manual abandoned-email form
- create a client-side test form for triggering the admin test send flow
- implement a protected API route that triggers EmailJS and stores the record in Supabase with idempotence

## Testing
- npm run build *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb7081f6c8332b3d794619a112d3c