### PR TITLE
Fix admin auth for test send and guard supabase client

### DIFF
--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -5,8 +5,10 @@ import TestForm from "../../components/TestForm";
 export const dynamic = "force-dynamic";
 
 export default function TestPage() {
-  const adm = cookies().get("adm")?.value;
-  if (!adm || adm !== process.env.ADMIN_TOKEN) redirect("/login");
+  const adminTokenCookie = cookies().get("admin_token")?.value;
+  if (!adminTokenCookie || adminTokenCookie !== process.env.ADMIN_TOKEN) {
+    redirect("/login");
+  }
 
   return (
     <main className="mx-auto max-w-lg p-6">


### PR DESCRIPTION
## Summary
- align the test page and admin test-send API to read the same admin cookie set during login
- wrap Supabase client creation so build succeeds even when environment variables are not configured

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdba1e4ce48332a07786921cdb3da2