### PR TITLE
Fix Supabase table name for abandoned emails

### DIFF
--- a/app/api/admin/resend/route.ts
+++ b/app/api/admin/resend/route.ts
@@ -46,7 +46,7 @@ export async function POST(request: NextRequest) {
   }
 
   const { data: record, error: fetchError } = await supabase
-    .from('abandoned_carts')
+    .from('abandoned_emails')
     .select('*')
     .eq('id', id)
     .single();
@@ -98,7 +98,7 @@ export async function POST(request: NextRequest) {
   }
 
   const { error: updateError } = await supabase
-    .from('abandoned_carts')
+    .from('abandoned_emails')
     .update({
       status: 'sent',
       discount_code: resolvedDiscount,

--- a/app/api/admin/test-send/route.ts
+++ b/app/api/admin/test-send/route.ts
@@ -28,7 +28,7 @@ async function ensureTestRecord(
   },
 ) {
   const { error } = await supabase
-    .from('abandoned_carts')
+    .from('abandoned_emails')
     .upsert(
       {
         id: params.id,
@@ -55,7 +55,7 @@ async function markTestAsSent(
   params: { id: string; discountCode: string | null; expiresAt: string | null; sentAt: string },
 ) {
   const { error } = await supabase
-    .from('abandoned_carts')
+    .from('abandoned_emails')
     .update({
       status: 'sent',
       discount_code: params.discountCode,
@@ -72,7 +72,7 @@ async function markTestAsSent(
 
 async function markTestAsError(supabase: ReturnType<typeof getSupabaseAdmin>, id: string) {
   const { error } = await supabase
-    .from('abandoned_carts')
+    .from('abandoned_emails')
     .update({
       status: 'error',
       last_event: 'manual.test.failed',

--- a/app/api/kiwify/webhook/route.ts
+++ b/app/api/kiwify/webhook/route.ts
@@ -83,7 +83,7 @@ export async function POST(request: NextRequest) {
   const recordId = data.id?.trim() || createCryptoId(identifierSeed);
 
   const { error } = await supabase
-    .from('abandoned_carts')
+    .from('abandoned_emails')
     .upsert(
       {
         id: recordId,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -51,7 +51,7 @@ async function fetchAbandonedCarts(): Promise<AbandonedCart[]> {
   try {
     const supabase = getSupabaseAdmin();
     const { data, error } = await supabase
-      .from('abandoned_carts')
+      .from('abandoned_emails')
       .select('*')
       .order('updated_at', { ascending: false })
       .limit(50);


### PR DESCRIPTION
## Summary
- replace Supabase queries that referenced the old `abandoned_carts` table name with `abandoned_emails`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdc35b9d0483328eb671497db2f8ae