### PR TITLE
Allow nullable email override in resend API

### DIFF
--- a/app/api/admin/resend/route.ts
+++ b/app/api/admin/resend/route.ts
@@ -6,7 +6,7 @@ import { getSupabaseAdmin } from '../../../../lib/supabaseAdmin';
 
 const resendSchema = z.object({
   id: z.string(),
-  email: z.string().email().optional(),
+  email: z.string().email().optional().nullable(),
   name: z.string().optional().nullable(),
   checkoutUrl: z.string().url().optional().nullable(),
   discountCode: z.string().optional().nullable(),


### PR DESCRIPTION
## Summary
- allow the admin resend endpoint to accept null email overrides so payloads coming from forms that send `null` pass validation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdded6cd9c8332af88f0cd6658c14b