### PR TITLE
Fix abandoned cart listing order column

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -53,7 +53,7 @@ async function fetchAbandonedCarts(): Promise<AbandonedCart[]> {
     const { data, error } = await supabase
       .from('abandoned_emails')
       .select('*')
-      .order('updated_at', { ascending: false })
+      .order('created_at', { ascending: false })
       .limit(50);
 
     if (error) {


### PR DESCRIPTION
## Summary
- order abandoned email listing by created_at so querying works when updated_at column is unavailable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdf5e73fe88332801c5cac18863f04