### PR TITLE
fix(test): incluir payload json no insert de admin test

### DIFF
--- a/app/api/admin/test/route.ts
+++ b/app/api/admin/test/route.ts
@@ -45,7 +45,10 @@ export async function POST(req: Request) {
     id
   ).toString();
 
-  const payload = {
+  const rawPayload =
+    body && typeof body === 'object' ? body : { note: 'manual.test', raw: String(body ?? '') };
+
+  const row = {
     id,
     event_id: id,
     email, // ✅ NOT NULL — sempre preenchido
@@ -63,14 +66,15 @@ export async function POST(req: Request) {
     source: 'manual.test.created',
     sent_at: null as any,
     updated_at: now.toISOString(),
+    payload: rawPayload,
   };
 
-  const { error } = await supabase.from('abandoned_emails').insert(payload);
+  const { error } = await supabase.from('abandoned_emails').insert(row);
 
   if (error) {
-    console.error('[kiwify-hub] erro ao registrar teste', error, { payload });
+    console.error('[kiwify-hub] erro ao registrar teste', error, { payload: row });
     return NextResponse.json({ ok: false, error }, { status: 500 });
   }
 
-  return NextResponse.json({ ok: true, id, email, schedule_at: payload.schedule_at });
+  return NextResponse.json({ ok: true, id, email, schedule_at: row.schedule_at });
 }


### PR DESCRIPTION
## Summary
- garantir que payload bruto seja preservado para inserts manuais de teste
- incluir a coluna json `payload` no objeto inserido na tabela `abandoned_emails`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce15d4fcf483329c5d56ef610485b2