### PR TITLE
Add emailjs node dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "rb-kiwify-hub",
       "version": "1.0.0",
       "dependencies": {
+        "@emailjs/nodejs": "^4.0.1",
         "@supabase/supabase-js": "^2.45.0",
         "clsx": "^2.1.1",
         "next": "14.2.3",
@@ -36,6 +37,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emailjs/nodejs": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@emailjs/nodejs/-/nodejs-4.1.0.tgz",
+      "integrity": "sha512-d97BsKytRhP9Nme66Hmk+S5HO+zQPJ0XZ+FsNERS8uxpSXvj6rEXUeOC49ilH8LAWOdb/eL8xhsM9tfpHrvkcA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@emailjs/nodejs": "^4.0.1",
     "@supabase/supabase-js": "^2.45.0",
     "clsx": "^2.1.1",
     "next": "14.2.3",


### PR DESCRIPTION
## Summary
- add the `@emailjs/nodejs` package to the project's dependencies
- update the npm lockfile by running `npm install`

## Testing
- npm install

------
https://chatgpt.com/codex/tasks/task_e_68ce86131fd08332811b788e28ab982d