### PR TITLE
Fix EmailJS strict mode by passing private key

### DIFF
--- a/app/api/admin/test/route.ts
+++ b/app/api/admin/test/route.ts
@@ -3,7 +3,7 @@ export const runtime = 'nodejs';
 
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
-import * as emailjs from '@emailjs/nodejs';
+import emailjs from '@emailjs/nodejs';
 import * as crypto from 'crypto';
 
 // --- EmailJS (Strict Mode: precisa PUBLIC + PRIVATE) ---
@@ -134,6 +134,10 @@ export async function POST(req: Request) {
           product_title: data.product_title,
           checkout_url: data.checkout_url,
           schedule_at: new Date(data.schedule_at).toLocaleString('pt-BR'),
+        },
+        {
+          publicKey: EMAIL_PUBLIC,
+          privateKey: EMAIL_PRIVATE,
         }
       );
     }


### PR DESCRIPTION
## Summary
- switch the EmailJS import to the default export recommended by the SDK
- pass both the public and private keys explicitly when sending test emails to satisfy strict mode

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce87515cd883329af442d49a7087d3