### PR TITLE
Include customer name in manual test email template params

### DIFF
--- a/app/api/admin/test-send/route.ts
+++ b/app/api/admin/test-send/route.ts
@@ -187,6 +187,7 @@ export async function POST(request: NextRequest) {
   const templateParams = {
     to_email: normalizedEmail,
     to_name: name ?? 'Cliente',
+    name: name ?? 'Cliente',
     product_name: productName ?? 'Produto Kiwify',
     checkout_url: checkoutUrl,
     discount_code: discountCode ?? '',


### PR DESCRIPTION
## Summary
- add the name field to the EmailJS template parameters used by the manual test send endpoint so templates can reference {{name}}

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d09e92957c8332baf585e6e48318d8