### PR TITLE
Add name to resend email template params

### DIFF
--- a/app/api/admin/resend/route.ts
+++ b/app/api/admin/resend/route.ts
@@ -72,6 +72,7 @@ export async function POST(request: NextRequest) {
   const templateParams = {
     to_email: email ?? record.customer_email,
     to_name: name ?? record.customer_name ?? 'Cliente',
+    name: name ?? record.customer_name ?? 'Cliente',
     product_name: record.product_name ?? 'Produto Kiwify',
     checkout_url: checkoutUrl ?? record.checkout_url ?? '',
     discount_code: resolvedDiscount ?? '',


### PR DESCRIPTION
## Summary
- include the customer's name in the resend email template parameters with proper fallbacks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0a44fbb108332a921deb88c6e6083