### PR TITLE
Add name parameter to admin test email

### DIFF
--- a/app/api/admin/test/route.ts
+++ b/app/api/admin/test/route.ts
@@ -131,6 +131,7 @@ export async function POST(req: Request) {
         {
           to_email: data.email,
           to_name: data.customer_name ?? 'Cliente',
+          name: data.customer_name ?? 'Cliente',
           product_title: data.product_title,
           checkout_url: data.checkout_url,
           schedule_at: new Date(data.schedule_at).toLocaleString('pt-BR'),


### PR DESCRIPTION
## Summary
- ensure admin test email payload passes customer name in the `name` field for EmailJS
- keep existing payload fields intact when sending the test email

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0a465aa148332a9dcd3fdf2d7010d