### PR TITLE
Remove to_name from EmailJS template params

### DIFF
--- a/app/api/admin/resend/route.ts
+++ b/app/api/admin/resend/route.ts
@@ -71,7 +71,6 @@ export async function POST(request: NextRequest) {
 
   const templateParams = {
     to_email: email ?? record.customer_email,
-    to_name: name ?? record.customer_name ?? 'Cliente',
     product_name: record.product_name ?? 'Produto Kiwify',
     checkout_url: checkoutUrl ?? record.checkout_url ?? '',
     discount_code: resolvedDiscount ?? '',

--- a/app/api/admin/test-send/route.ts
+++ b/app/api/admin/test-send/route.ts
@@ -186,7 +186,6 @@ export async function POST(request: NextRequest) {
 
   const templateParams = {
     to_email: normalizedEmail,
-    to_name: name ?? 'Cliente',
     name: name ?? 'Cliente',
     product_name: productName ?? 'Produto Kiwify',
     checkout_url: checkoutUrl,

--- a/app/api/admin/test/route.ts
+++ b/app/api/admin/test/route.ts
@@ -130,7 +130,6 @@ export async function POST(req: Request) {
         EMAIL_TEMPLATE,
         {
           to_email: data.email,
-          to_name: data.customer_name ?? 'Cliente',
           product_title: data.product_title,
           checkout_url: data.checkout_url,
           schedule_at: new Date(data.schedule_at).toLocaleString('pt-BR'),


### PR DESCRIPTION
## Summary
- remove the deprecated to_name field from all EmailJS template payloads in the admin APIs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0a48553148332a7be22eacf3caaa5