### PR TITLE
Permite reenvio manual usando token da sessão

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Use um arquivo `.env.local` para valores de desenvolvimento.
 
 ## Rotas principais
 - `POST /api/kiwify/webhook`: recebe eventos da Kiwify e registra o carrinho no Supabase.
-- `POST /api/admin/resend`: reenviar o e-mail manualmente (necessita header `Authorization: Bearer ADMIN_TOKEN`).
+- `POST /api/admin/resend`: reenviar o e-mail manualmente (necessita cookie `admin_token` válido ou header `Authorization: Bearer ADMIN_TOKEN`).
 
 ## Login administrativo
 Acesse `/login` e informe o valor configurado em `ADMIN_TOKEN` para destravar o painel protegido por cookie.

--- a/app/api/admin/resend/route.ts
+++ b/app/api/admin/resend/route.ts
@@ -18,8 +18,11 @@ const EMAILJS_ENDPOINT = 'https://api.emailjs.com/api/v1.0/email/send';
 export async function POST(request: NextRequest) {
   const adminToken = process.env.ADMIN_TOKEN;
   const header = request.headers.get('authorization');
+  const cookieToken = request.cookies.get('admin_token')?.value;
 
-  if (!adminToken || header !== `Bearer ${adminToken}`) {
+  const isAuthorized = header === `Bearer ${adminToken}` || cookieToken === adminToken;
+
+  if (!adminToken || !isAuthorized) {
     return NextResponse.json({ error: 'Não autorizado.' }, { status: 401 });
   }
 

--- a/components/AbandonedCartsTable.tsx
+++ b/components/AbandonedCartsTable.tsx
@@ -16,18 +16,6 @@ type FeedbackState = {
   message: string;
 };
 
-function getCookie(name: string): string | null {
-  if (typeof document === 'undefined') return null;
-  const entry = document.cookie.split('; ').find((part) => part.startsWith(`${name}=`));
-  if (!entry) return null;
-  const value = entry.split('=').slice(1).join('=');
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value;
-  }
-}
-
 export default function AbandonedCartsTable({ carts }: AbandonedCartsTableProps) {
   const [data, setData] = useState<AbandonedCart[]>(carts);
   const [expandedId, setExpandedId] = useState<string | null>(null);
@@ -73,11 +61,6 @@ export default function AbandonedCartsTable({ carts }: AbandonedCartsTableProps)
   const handleSendEmail = useCallback(
     async (item: AbandonedCart) => {
       if (sendingId) return;
-      const token = getCookie('admin_token');
-      if (!token) {
-        setFeedback((prev) => ({ ...prev, [item.id]: { type: 'error', message: 'Token administrativo ausente.' } }));
-        return;
-      }
 
       setSendingId(item.id);
       setFeedback((prev) => ({ ...prev, [item.id]: undefined }));
@@ -87,7 +70,6 @@ export default function AbandonedCartsTable({ carts }: AbandonedCartsTableProps)
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
           },
           body: JSON.stringify({ id: item.id }),
         });


### PR DESCRIPTION
## Summary
- permite que a API de reenvio valide o token administrativo a partir do cookie da sessão
- remove a leitura do cookie no cliente ao reenviar e-mail e evita erro de token ausente
- atualiza a documentação para refletir o novo método de autenticação

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0ab9ab1c08332a30ece8eef2aff0c