### PR TITLE
Use default discount code in cron dispatch

### DIFF
--- a/app/api/admin/cron/dispatch/route.ts
+++ b/app/api/admin/cron/dispatch/route.ts
@@ -5,6 +5,7 @@ import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import * as emailjs from '@emailjs/nodejs';
 import { applyDiscountToCheckoutUrl } from '../../../../../lib/checkout';
+import { resolveDiscountCode } from '../../../../../lib/cryptoId';
 
 const SUPABASE_URL = process.env.SUPABASE_URL!;
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
@@ -66,7 +67,7 @@ export async function POST(req: Request) {
   let sent = 0;
   for (const r of rows) {
     try {
-      const discountCode = r.discount_code ?? 'RB10';
+      const discountCode = resolveDiscountCode(r.discount_code);
       await emailjs.send(
         EMAIL_SERVICE,
         EMAIL_TEMPLATE,


### PR DESCRIPTION
## Summary
- reuse `resolveDiscountCode` in the cron dispatch endpoint so pending emails fall back to the default discount code when none is stored

## Testing
- TS_NODE_COMPILER_OPTIONS='{"allowImportingTsExtensions":true}' DEFAULT_DISCOUNT_CODE=ENVTEST node --loader ts-node/esm tmp-test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d0c456f0e48332a377070dadb63fe3