### PR TITLE
Allow NEXT_PUBLIC_SUPABASE_URL fallback in admin routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,18 @@ Hub interno para monitorar carrinhos abandonados da Kiwify e reenviar lembretes 
 ## Variáveis de ambiente
 Configure as seguintes chaves antes de rodar o projeto:
 
-- `NEXT_PUBLIC_SUPABASE_URL`
-- `SUPABASE_SERVICE_ROLE_KEY`
+### Supabase
+- `SUPABASE_SERVICE_ROLE_KEY` (privada)
+- `SUPABASE_URL` (privada — opcional; caso não defina, as rotas server usam o fallback `NEXT_PUBLIC_SUPABASE_URL`)
+- `NEXT_PUBLIC_SUPABASE_URL` (pública — obrigatória para o client e agora fallback do server)
+
+### EmailJS
 - `EMAILJS_SERVICE_ID` (ou `NEXT_PUBLIC_EMAILJS_SERVICE_ID`)
 - `EMAILJS_TEMPLATE_ID` (ou `NEXT_PUBLIC_EMAILJS_TEMPLATE_ID`)
 - `EMAILJS_PUBLIC_KEY` (ou `NEXT_PUBLIC_EMAILJS_PUBLIC_KEY`)
+- `EMAILJS_PRIVATE_KEY` (mantida apenas no server)
+
+### Outras variáveis
 - `KIWIFY_WEBHOOK_TOKEN`
 - `ADMIN_TOKEN`
 - `DEFAULT_DISCOUNT_CODE`

--- a/app/api/admin/cron/dispatch/route.ts
+++ b/app/api/admin/cron/dispatch/route.ts
@@ -6,7 +6,11 @@ import { createClient } from '@supabase/supabase-js';
 import * as emailjs from '@emailjs/nodejs';
 import { applyDiscountToCheckoutUrl } from '../../../../../lib/checkout';
 
-const SUPABASE_URL = process.env.SUPABASE_URL!;
+const SUPABASE_URL =
+  (process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL ?? '').trim();
+if (!SUPABASE_URL) {
+  throw new Error('Missing SUPABASE_URL or NEXT_PUBLIC_SUPABASE_URL');
+}
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 const ADMIN_TOKEN = (process.env.ADMIN_TOKEN ?? '').trim();
 

--- a/app/api/admin/events/route.ts
+++ b/app/api/admin/events/route.ts
@@ -5,7 +5,11 @@ export const dynamic = 'force-dynamic';
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 
-const SUPABASE_URL = process.env.SUPABASE_URL!;
+const SUPABASE_URL =
+  (process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL ?? '').trim();
+if (!SUPABASE_URL) {
+  throw new Error('Missing SUPABASE_URL or NEXT_PUBLIC_SUPABASE_URL');
+}
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 const ADMIN_TOKEN = (process.env.ADMIN_TOKEN ?? '').trim();
 

--- a/app/api/admin/test/route.ts
+++ b/app/api/admin/test/route.ts
@@ -20,10 +20,11 @@ if (EMAIL_PUBLIC && EMAIL_PRIVATE) {
 
 export async function POST(req: Request) {
   // --- Env guards úteis (erros mais claros) ---
-  const supabaseUrl = process.env.SUPABASE_URL || '';
-  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+  const supabaseUrl =
+    (process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL ?? '').trim();
+  const supabaseKey = (process.env.SUPABASE_SERVICE_ROLE_KEY ?? '').trim();
   if (!supabaseUrl || !supabaseKey) {
-    console.error('[env] faltam SUPABASE_URL ou SUPABASE_SERVICE_ROLE_KEY');
+    console.error('[env] faltam SUPABASE_URL/NEXT_PUBLIC_SUPABASE_URL ou SUPABASE_SERVICE_ROLE_KEY');
     return NextResponse.json({ ok: false, error: 'env_missing_supabase' }, { status: 500 });
   }
 

--- a/app/api/kiwify/webhook/route.ts
+++ b/app/api/kiwify/webhook/route.ts
@@ -6,7 +6,11 @@ import { createClient } from '@supabase/supabase-js';
 import * as crypto from 'crypto';
 
 // ==== ENVS OBRIGATÓRIAS ====
-const SUPABASE_URL = process.env.SUPABASE_URL!;
+const SUPABASE_URL =
+  (process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL ?? '').trim();
+if (!SUPABASE_URL) {
+  throw new Error('Missing SUPABASE_URL or NEXT_PUBLIC_SUPABASE_URL');
+}
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
 // ==== ENVS OPCIONAIS ====


### PR DESCRIPTION
## Summary
- allow admin cron dispatch, events, test and Kiwify webhook routes to fall back to NEXT_PUBLIC_SUPABASE_URL when SUPABASE_URL is missing
- tighten the Supabase env guard in the admin test helper to mention the new fallback
- document the public and private environment variables, including the Supabase URL fallback, in the README

## Testing
- NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:9999 SUPABASE_SERVICE_ROLE_KEY=service CI=1 npm run build
- NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:9999 SUPABASE_SERVICE_ROLE_KEY=service EMAILJS_PUBLIC_KEY=dummy EMAILJS_PRIVATE_KEY= EMAILJS_SERVICE_ID= EMAILJS_TEMPLATE_ID= DEFAULT_DELAY_HOURS=24 DEFAULT_EXPIRE_HOURS=24 npm run dev & curl -s -X POST http://localhost:3000/api/admin/cron/dispatch
- curl -s http://localhost:3000/api/admin/events
- curl -s -X POST http://localhost:3000/api/admin/test -H 'Content-Type: application/json' -d '{"email":"teste@example.com"}'
- curl -s -X POST http://localhost:3000/api/kiwify/webhook -H 'Content-Type: application/json' -d '{"email":"buyer@example.com","name":"Comprador","checkout_link":"ABC123"}'


------
https://chatgpt.com/codex/tasks/task_e_68d0c476610483328b5ac0a5f5655fa2