### PR TITLE
Implement full dispatch batching and table pagination

### DIFF
--- a/components/Table.tsx
+++ b/components/Table.tsx
@@ -30,63 +30,73 @@ export default function Table<T extends Record<string, unknown>>({
   renderExpandedRow,
 }: TableProps<T>) {
   return (
-    <div className={clsx('overflow-hidden rounded-xl border border-slate-800 bg-slate-900/60 shadow-lg', className)}>
-      <table className="min-w-full divide-y divide-slate-800">
-        <thead className="bg-slate-900/80">
-          <tr>
-            {columns.map((column) => (
-              <th
-                key={String(column.key)}
-                scope="col"
-                className={clsx('px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-400', column.className)}
-              >
-                {column.header}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-slate-800">
-          {data.length === 0 ? (
+    <div
+      className={clsx(
+        'rounded-xl border border-slate-800 bg-slate-900/60 shadow-lg sm:overflow-hidden',
+        className,
+      )}
+    >
+      <div className="overflow-x-auto">
+        <table className="min-w-[720px] divide-y divide-slate-800 sm:min-w-full">
+          <thead className="bg-slate-900/80">
             <tr>
-              <td colSpan={columns.length} className="px-4 py-6 text-center text-sm text-slate-400">
-                {emptyMessage}
-              </td>
+              {columns.map((column) => (
+                <th
+                  key={String(column.key)}
+                  scope="col"
+                  className={clsx(
+                    'px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-400',
+                    column.className,
+                  )}
+                >
+                  {column.header}
+                </th>
+              ))}
             </tr>
-          ) : (
-            data.map((item, index) => {
-              const key = getRowKey ? getRowKey(item, index) : index;
-              const stringKey = String(key);
-              const isExpanded = expandedRowKey !== null && String(expandedRowKey) === stringKey;
+          </thead>
+          <tbody className="divide-y divide-slate-800">
+            {data.length === 0 ? (
+              <tr>
+                <td colSpan={columns.length} className="px-4 py-6 text-center text-sm text-slate-400">
+                  {emptyMessage}
+                </td>
+              </tr>
+            ) : (
+              data.map((item, index) => {
+                const key = getRowKey ? getRowKey(item, index) : index;
+                const stringKey = String(key);
+                const isExpanded = expandedRowKey !== null && String(expandedRowKey) === stringKey;
 
-              return (
-                <Fragment key={stringKey}>
-                  <tr
-                    className={clsx(
-                      'hover:bg-slate-800/30',
-                      onRowClick && 'cursor-pointer',
-                      isExpanded && 'bg-slate-800/40',
-                    )}
-                    onClick={() => onRowClick?.(item, index)}
-                  >
-                    {columns.map((column) => (
-                      <td key={String(column.key)} className={clsx('px-4 py-3 text-sm text-slate-200', column.className)}>
-                        {column.render ? column.render(item) : String(item[column.key] ?? '')}
-                      </td>
-                    ))}
-                  </tr>
-                  {isExpanded && renderExpandedRow ? (
-                    <tr className="bg-slate-900/70">
-                      <td colSpan={columns.length} className="px-4 py-4 text-sm text-slate-200">
-                        {renderExpandedRow(item)}
-                      </td>
+                return (
+                  <Fragment key={stringKey}>
+                    <tr
+                      className={clsx(
+                        'hover:bg-slate-800/30',
+                        onRowClick && 'cursor-pointer',
+                        isExpanded && 'bg-slate-800/40',
+                      )}
+                      onClick={() => onRowClick?.(item, index)}
+                    >
+                      {columns.map((column) => (
+                        <td key={String(column.key)} className={clsx('px-4 py-3 text-sm text-slate-200', column.className)}>
+                          {column.render ? column.render(item) : String(item[column.key] ?? '')}
+                        </td>
+                      ))}
                     </tr>
-                  ) : null}
-                </Fragment>
-              );
-            })
-          )}
-        </tbody>
-      </table>
+                    {isExpanded && renderExpandedRow ? (
+                      <tr className="bg-slate-900/70">
+                        <td colSpan={columns.length} className="px-4 py-4 text-sm text-slate-200">
+                          {renderExpandedRow(item)}
+                        </td>
+                      </tr>
+                    ) : null}
+                  </Fragment>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- update the cron dispatch API to iterate through pending abandoned carts in batches until none remain
- add client-side pagination at 20 records per page with navigation controls on the abandoned carts hub table
- tweak the shared table component to allow horizontal scrolling on small screens while keeping the desktop presentation

## Testing
- `npm run build` *(fails: Missing SUPABASE_URL or NEXT_PUBLIC_SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d1fb245c83329884e12acfc33e5c