### PR TITLE
Add conversion status indicator for abandoned carts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -38,6 +38,9 @@ async function fetchAbandonedCarts(): Promise<AbandonedCart[]> {
     return rows.map((r): AbandonedCart => {
       const p = (r?.payload ?? {}) as Record<string, any>;
       const productFromPayload = clean(p.product_name) || clean(p.offer_name) || '';
+      const paid = Boolean(r?.paid);
+      const baseStatus = r?.status || 'pending';
+      const normalizedStatus = paid ? 'converted' : baseStatus;
 
       return {
         id: String(r.id),
@@ -49,7 +52,9 @@ async function fetchAbandonedCarts(): Promise<AbandonedCart[]> {
           productFromPayload ||
           null,
         product_id: r.product_id ?? null,
-        status: r.status || 'pending',
+        status: normalizedStatus,
+        paid,
+        paid_at: r.paid_at ?? null,
         discount_code: clean(r.discount_code) || clean((p as any)?.coupon) || null,
         // expiração/agendamento: aceita expires_at ou schedule_at
         expires_at: r.expires_at ?? r.schedule_at ?? null,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,6 +5,8 @@ export type AbandonedCart = {
   product_name: string | null;
   product_id: string | null;
   status: string;
+  paid: boolean;
+  paid_at: string | null;
   discount_code: string | null;
   expires_at: string | null; // schedule_at / expires_at
   last_event: string | null;


### PR DESCRIPTION
## Summary
- normalize abandoned cart statuses using Supabase payment metadata to mark conversions
- add UI indicator next to customer names showing awaiting conversion or converted status
- keep conversion state when resending emails and reset indicators while paginating the table

## Testing
- `npm run build` *(fails: Missing SUPABASE_URL or NEXT_PUBLIC_SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68d1bdc177e88332bc7e624729a28f4f