### PR TITLE
Add status sort toggle to abandoned carts table

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,6 @@
 // app/page.tsx
 import Card from '../components/Card';
-import Badge from '../components/Badge';
-import AbandonedCartsTable from '../components/AbandonedCartsTable';
+import AbandonedCartsSection from '../components/AbandonedCartsSection';
 import { getSupabaseAdmin } from '../lib/supabaseAdmin';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
@@ -114,16 +113,7 @@ export default async function Home() {
         <Card title="Convertidos" value={metrics.converted} description="Clientes que finalizaram a compra" />
       </section>
 
-      <section className="flex flex-col gap-4">
-        <div className="flex items-center justify-between">
-          <h2 className="text-xl font-semibold">Eventos recebidos</h2>
-          <Badge variant={metrics.expired > 0 ? 'error' : 'pending'}>
-            {metrics.expired > 0 ? `${metrics.expired} link(s) expirados` : 'Todos os links ativos'}
-          </Badge>
-        </div>
-
-        <AbandonedCartsTable carts={carts} />
-      </section>
+      <AbandonedCartsSection carts={carts} expiredCount={metrics.expired} />
     </main>
   );
 }

--- a/components/AbandonedCartsSection.tsx
+++ b/components/AbandonedCartsSection.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Badge from './Badge';
+import AbandonedCartsTable, { type AbandonedCartSortMode } from './AbandonedCartsTable';
+import type { AbandonedCart } from '../lib/types';
+
+type AbandonedCartsSectionProps = {
+  carts: AbandonedCart[];
+  expiredCount: number;
+};
+
+export default function AbandonedCartsSection({ carts, expiredCount }: AbandonedCartsSectionProps) {
+  const [sortMode, setSortMode] = useState<AbandonedCartSortMode>('default');
+
+  const { buttonLabel, buttonTitle } = useMemo(() => {
+    if (sortMode === 'status') {
+      return {
+        buttonLabel: 'Ordenar por data',
+        buttonTitle: 'Voltar a ordenar pelos eventos mais recentes.',
+      };
+    }
+
+    return {
+      buttonLabel: 'Ordenar por status',
+      buttonTitle: 'Ordenar por status: enviados, pendentes e convertidos.',
+    };
+  }, [sortMode]);
+
+  const handleToggleSort = () => {
+    setSortMode((current) => (current === 'status' ? 'default' : 'status'));
+  };
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <h2 className="text-xl font-semibold">Eventos recebidos</h2>
+          <button
+            type="button"
+            onClick={handleToggleSort}
+            className="inline-flex items-center rounded-md border border-slate-700 px-3 py-1 text-xs font-medium text-slate-200 transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/70 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 sm:text-sm"
+            title={buttonTitle}
+            aria-pressed={sortMode === 'status'}
+          >
+            {buttonLabel}
+          </button>
+        </div>
+        <Badge variant={expiredCount > 0 ? 'error' : 'pending'}>
+          {expiredCount > 0 ? `${expiredCount} link(s) expirados` : 'Todos os links ativos'}
+        </Badge>
+      </div>
+
+      <AbandonedCartsTable carts={carts} sortMode={sortMode} />
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated client section for the abandoned carts table with a toggle button next to the "Eventos recebidos" heading
- allow the table to sort carts by status in the order enviados, pendentes e convertidos while preserving the existing pagination and expansion behaviour

## Testing
- npm run build *(fails: missing SUPABASE_URL or NEXT_PUBLIC_SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68d1d6f80b6483329bfece789ab6dfc2