### PR TITLE
Cycle priority status on abandoned carts table

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,6 @@
 // app/page.tsx
 import Card from '../components/Card';
-import Badge from '../components/Badge';
-import AbandonedCartsTable from '../components/AbandonedCartsTable';
+import AbandonedCartsSection from '../components/AbandonedCartsSection';
 import { getSupabaseAdmin } from '../lib/supabaseAdmin';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
@@ -114,16 +113,7 @@ export default async function Home() {
         <Card title="Convertidos" value={metrics.converted} description="Clientes que finalizaram a compra" />
       </section>
 
-      <section className="flex flex-col gap-4">
-        <div className="flex items-center justify-between">
-          <h2 className="text-xl font-semibold">Eventos recebidos</h2>
-          <Badge variant={metrics.expired > 0 ? 'error' : 'pending'}>
-            {metrics.expired > 0 ? `${metrics.expired} link(s) expirados` : 'Todos os links ativos'}
-          </Badge>
-        </div>
-
-        <AbandonedCartsTable carts={carts} />
-      </section>
+      <AbandonedCartsSection carts={carts} expiredCount={metrics.expired} />
     </main>
   );
 }

--- a/components/AbandonedCartsSection.tsx
+++ b/components/AbandonedCartsSection.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Badge from './Badge';
+import AbandonedCartsTable, { type AbandonedCartPriority } from './AbandonedCartsTable';
+import type { AbandonedCart } from '../lib/types';
+import { STATUS_LABEL } from '../lib/status';
+
+const STATUS_SEQUENCE: AbandonedCartPriority[] = ['pending', 'converted', 'sent'];
+
+type AbandonedCartsSectionProps = {
+  carts: AbandonedCart[];
+  expiredCount: number;
+};
+
+export default function AbandonedCartsSection({ carts, expiredCount }: AbandonedCartsSectionProps) {
+  const [priorityIndex, setPriorityIndex] = useState<number>(-1);
+
+  const priorityStatus = priorityIndex === -1 ? null : STATUS_SEQUENCE[priorityIndex];
+
+  const { buttonLabel, buttonTitle, nextIndex } = useMemo(() => {
+    const next = (priorityIndex + 1) % STATUS_SEQUENCE.length;
+    const nextStatus = STATUS_SEQUENCE[next];
+
+    if (!priorityStatus) {
+      return {
+        buttonLabel: 'Pendentes no topo',
+        buttonTitle:
+          'Clique para colocar os pendentes no topo da tabela. Clique novamente para alternar entre convertidos e enviados.',
+        nextIndex: next,
+      };
+    }
+
+    const label = STATUS_LABEL[priorityStatus];
+    const nextLabel = STATUS_LABEL[nextStatus];
+
+    return {
+      buttonLabel: `${label} no topo`,
+      buttonTitle: `Clique para priorizar ${nextLabel.toLowerCase()} na próxima visualização.`,
+      nextIndex: next,
+    };
+  }, [priorityIndex, priorityStatus]);
+
+  const handleTogglePriority = () => {
+    setPriorityIndex(nextIndex);
+  };
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <h2 className="text-xl font-semibold">Eventos recebidos</h2>
+          <button
+            type="button"
+            onClick={handleTogglePriority}
+            className="inline-flex items-center rounded-md border border-slate-700 px-3 py-1 text-xs font-medium text-slate-200 transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/70 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 sm:text-sm"
+            title={buttonTitle}
+            aria-pressed={priorityStatus ? true : false}
+          >
+            {buttonLabel}
+          </button>
+        </div>
+        <Badge variant={expiredCount > 0 ? 'error' : 'pending'}>
+          {expiredCount > 0 ? `${expiredCount} link(s) expirados` : 'Todos os links ativos'}
+        </Badge>
+      </div>
+
+      <AbandonedCartsTable carts={carts} priorityStatus={priorityStatus} />
+    </section>
+  );
+}

--- a/components/AbandonedCartsTable.tsx
+++ b/components/AbandonedCartsTable.tsx
@@ -7,8 +7,11 @@ import type { AbandonedCart } from '../lib/types';
 import { formatSaoPaulo } from '../lib/dates';
 import { getBadgeVariant, STATUS_LABEL } from '../lib/status';
 
+export type AbandonedCartPriority = 'pending' | 'converted' | 'sent';
+
 type AbandonedCartsTableProps = {
   carts: AbandonedCart[];
+  priorityStatus?: AbandonedCartPriority | null;
 };
 
 type FeedbackState = {
@@ -18,7 +21,13 @@ type FeedbackState = {
 
 const PAGE_SIZE = 20;
 
-export default function AbandonedCartsTable({ carts }: AbandonedCartsTableProps) {
+const getTimestamp = (value?: string | null) => {
+  if (!value) return 0;
+  const time = Date.parse(value);
+  return Number.isNaN(time) ? 0 : time;
+};
+
+export default function AbandonedCartsTable({ carts, priorityStatus = null }: AbandonedCartsTableProps) {
   const [data, setData] = useState<AbandonedCart[]>(carts);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [sendingId, setSendingId] = useState<string | null>(null);
@@ -167,7 +176,30 @@ export default function AbandonedCartsTable({ carts }: AbandonedCartsTableProps)
     [sendingId],
   );
 
-  const totalItems = data.length;
+  const sortedData = useMemo(() => {
+    if (!priorityStatus) {
+      return data;
+    }
+
+    return [...data].sort((a, b) => {
+      const aPriority = a.status === priorityStatus ? 0 : 1;
+      const bPriority = b.status === priorityStatus ? 0 : 1;
+
+      if (aPriority !== bPriority) {
+        return aPriority - bPriority;
+      }
+
+      const timeB = getTimestamp(b.updated_at ?? b.created_at);
+      const timeA = getTimestamp(a.updated_at ?? a.created_at);
+      return timeB - timeA;
+    });
+  }, [data, priorityStatus]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [priorityStatus]);
+
+  const totalItems = sortedData.length;
   const totalPages = Math.max(1, Math.ceil(totalItems / PAGE_SIZE));
 
   useEffect(() => {
@@ -178,8 +210,8 @@ export default function AbandonedCartsTable({ carts }: AbandonedCartsTableProps)
 
   const paginatedData = useMemo(() => {
     const startIndex = (currentPage - 1) * PAGE_SIZE;
-    return data.slice(startIndex, startIndex + PAGE_SIZE);
-  }, [currentPage, data]);
+    return sortedData.slice(startIndex, startIndex + PAGE_SIZE);
+  }, [currentPage, sortedData]);
 
   useEffect(() => {
     if (expandedId && !paginatedData.some((row) => row.id === expandedId)) {


### PR DESCRIPTION
## Summary
- update the abandoned carts section button to cycle the priority between pendentes, convertidos e enviados, destacando o status atual no rótulo
- adjust the abandoned carts table to receber o status prioritário e ordenar os registros para que o status selecionado fique no topo mantendo a ordenação por data para os demais itens

## Testing
- npm run build *(fails: Missing SUPABASE_URL or NEXT_PUBLIC_SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68d1d6f80b6483329bfece789ab6dfc2