### PR TITLE
Normalize checkout IDs when migrating legacy rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Acesse `/login` e informe o valor configurado em `ADMIN_TOKEN` para destravar o 
 - `npm run dev`
 - `npm run build`
 - `npm run start`
-- `node scripts/backfill_checkout_ids.mjs` — gera um `checkout_id` determinístico para registros antigos da tabela `abandoned_emails`
+- `node scripts/backfill_checkout_ids.mjs` — reprocessa registros antigos aplicando o mesmo algoritmo de `checkout_id` determinístico (e-mail + código de checkout/produto) usado pelo webhook na tabela `abandoned_emails`
 
 ### Backfill dos `checkout_id`
 
@@ -56,7 +56,7 @@ O script `scripts/backfill_checkout_ids.mjs` ajuda a atualizar registros existen
    node scripts/backfill_checkout_ids.mjs
    ```
 
-   Esse modo lista os registros que receberiam o novo `checkout_id`, os grupos duplicados detectados e os itens ignorados por falta de e-mail ou produto.
+   Esse modo lista os registros que receberiam o novo `checkout_id`, os grupos duplicados detectados e os itens ignorados por falta de e-mail, produto ou referência de checkout.
 
 3. Se estiver tudo certo, aplique as alterações:
 
@@ -66,5 +66,5 @@ O script `scripts/backfill_checkout_ids.mjs` ajuda a atualizar registros existen
 
    Adicione `--delete-duplicates` se quiser remover automaticamente as linhas antigas com o mesmo e-mail/produto (o script preserva a melhor linha de cada grupo antes de excluir as demais).
 
-4. Caso algum registro apareça como “skipped”, complete manualmente o `customer_email` e o identificador/título do produto antes de rodar novamente.
+4. Caso algum registro apareça como “skipped”, complete manualmente o `customer_email`, o identificador/título do produto ou algum código/link de checkout antes de rodar novamente.
 


### PR DESCRIPTION
## Summary
- prefer the canonical hashed checkout identifier for new webhook events and reuse it when selecting existing records
- migrate legacy rows that still store raw checkout IDs to the canonical value, falling back to the best-matching record if the migration hits a conflict

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d36dccdedc8332ad7f83637f7a7914