### PR TITLE
Propagate converted status across duplicate carts

### DIFF
--- a/app/api/kiwify/webhook/route.ts
+++ b/app/api/kiwify/webhook/route.ts
@@ -1097,7 +1097,9 @@ async function propagateConvertedStatus(args: {
 
   const emailColumns: Array<'customer_email' | 'email'> = ['customer_email', 'email'];
 
-  for (const variant of emailVariants) {
+  const emailVariantList = Array.from(emailVariants);
+
+  for (const variant of emailVariantList) {
     for (const column of emailColumns) {
       const query = supabase
         .from('abandoned_emails')


### PR DESCRIPTION
## Summary
- add helpers to normalize email/status strings when matching duplicate carts
- propagate converted status, paid flag, and timestamps to every matching record for the same email/product or checkout ID
- reuse a single ISO timestamp during webhook processing to keep updates consistent

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d382b7e0f48332972508e3aa0c01e9