### PR TITLE
Fix URLSearchParams iteration for older targets

### DIFF
--- a/lib/ads.test.ts
+++ b/lib/ads.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { computeAdPerformance } from './ads';
+
+describe('computeAdPerformance', () => {
+  it('detects UTM parameters inside TrackingParameters', () => {
+    const rows = [
+      {
+        id: 'test',
+        paid: false,
+        status: 'pending',
+        traffic_source: 'tiktok.paid',
+        payload: {
+          TrackingParameters: {
+            utm_source: 'tiktok',
+            utm_medium: 'paid',
+            utm_campaign: 'adstiktok',
+          },
+        },
+        created_at: '2024-01-01T00:00:00.000Z',
+        updated_at: '2024-01-01T00:00:00.000Z',
+      },
+    ];
+
+    const result = computeAdPerformance(rows);
+    expect(result).toHaveLength(1);
+    expect(result[0].utmSource).toBe('tiktok');
+    expect(result[0].utmMedium).toBe('paid');
+    expect(result[0].utmCampaign).toBe('adstiktok');
+  });
+});

--- a/lib/ads.ts
+++ b/lib/ads.ts
@@ -52,7 +52,12 @@ function getValueByPath(source: UnknownRecord | undefined | null, path: string):
       }
     } else if (typeof current === 'object') {
       const record = current as UnknownRecord;
-      current = record[segment];
+      const lowerSegment = segment.toLowerCase();
+      const matchingKey = Object.keys(record).find((key) => key.toLowerCase() === lowerSegment);
+      if (!matchingKey) {
+        return undefined;
+      }
+      current = record[matchingKey];
     } else {
       return undefined;
     }
@@ -248,6 +253,7 @@ const CTA_CLICK_PATHS = [
 const UTM_SOURCE_PATHS = [
   'utm_source',
   'utmSource',
+  'trackingparameters.utm_source',
   'traffic_source',
   'trafficSource',
   'source_platform',
@@ -257,6 +263,7 @@ const UTM_SOURCE_PATHS = [
 const UTM_MEDIUM_PATHS = [
   'utm_medium',
   'utmMedium',
+  'trackingparameters.utm_medium',
   'traffic_medium',
   'campaign_medium',
   'marketing_medium',
@@ -265,6 +272,7 @@ const UTM_MEDIUM_PATHS = [
 const UTM_CAMPAIGN_PATHS = [
   'utm_campaign',
   'utmCampaign',
+  'trackingparameters.utm_campaign',
   'campaign',
   'campaign_name',
   'campaignName',


### PR DESCRIPTION
## Summary
- merge UTM parameters detected in webhook payloads into the stored checkout URL so resend emails reuse paid-media tags
- broaden traffic source parsing to handle nested TrackingParameters keys and reuse the enriched checkout URL when classifying traffic
- make ad metric extraction path lookups case-insensitive and cover TrackingParameters, adding a regression test for the ads aggregations
- ensure URLSearchParams iteration uses forEach so builds targeting below ES2015 succeed without additional flags

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3c37fdb448332ac201b040a047c96