### PR TITLE
Add TikTok organic manual reminder coverage

### DIFF
--- a/app/api/admin/resend/route.ts
+++ b/app/api/admin/resend/route.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 import { resolveDiscountCode, resolveExpiration } from '../../../../lib/cryptoId';
 import { getEmailJsConfig } from '../../../../lib/emailJsConfig';
 import { getSupabaseAdmin } from '../../../../lib/supabaseAdmin';
-import { applyDiscountToCheckoutUrl } from '../../../../lib/checkout';
+import {
+  applyDiscountToCheckoutUrl,
+  applyManualTrackingToCheckoutUrl,
+} from '../../../../lib/checkout';
 
 const resendSchema = z.object({
   id: z.string(),
@@ -73,9 +76,11 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Serviço de e-mail indisponível.' }, { status: 500 });
   }
 
-  const resolvedCheckoutUrl = applyDiscountToCheckoutUrl(
-    checkoutUrl ?? record.checkout_url ?? '',
-    resolvedDiscount,
+  const resolvedCheckoutUrl = applyManualTrackingToCheckoutUrl(
+    applyDiscountToCheckoutUrl(checkoutUrl ?? record.checkout_url ?? '', resolvedDiscount),
+    {
+      trafficSource: record.traffic_source ?? null,
+    },
   );
 
   const normalizeString = (value: unknown): string | null => {

--- a/app/api/kiwify/webhook/route.test.ts
+++ b/app/api/kiwify/webhook/route.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { extractTrafficSource } from './route';
+
+const baseCheckout = 'https://pay.example.com/checkout';
+
+describe('extractTrafficSource - manual reminders', () => {
+  it('classifica lembretes manuais sem pista paga como organic.email', () => {
+    const checkoutUrl =
+      `${baseCheckout}?rb_manual=email&utm_source=manual-email&utm_medium=email&utm_campaign=manual-reminder`;
+
+    const result = extractTrafficSource({}, checkoutUrl, null);
+
+    expect(result).toBe('organic.email');
+  });
+
+  it('mantém o canal pago ao adicionar o sufixo .email', () => {
+    const checkoutUrl =
+      `${baseCheckout}?rb_manual=email&utm_source=tiktok&utm_medium=paid&utm_campaign=manual-reminder`;
+
+    const result = extractTrafficSource({}, checkoutUrl, 'tiktok.paid');
+
+    expect(result).toBe('tiktok.paid.email');
+  });
+
+  it('mantém o canal orgânico quando o manual vem de um tiktok orgânico', () => {
+    const checkoutUrl =
+      `${baseCheckout}?rb_manual=email&utm_source=manual-email&utm_medium=email&utm_campaign=manual-reminder`;
+
+    const result = extractTrafficSource({}, checkoutUrl, 'tiktok.organic');
+
+    expect(result).toBe('tiktok.organic.email');
+  });
+});

--- a/lib/checkout.test.ts
+++ b/lib/checkout.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { applyManualTrackingToCheckoutUrl } from './checkout';
+
+describe('applyManualTrackingToCheckoutUrl', () => {
+  it('adiciona rastreamento manual e parâmetros padrão para links sem UTM', () => {
+    const url = 'https://pay.example.com/checkout?foo=bar';
+
+    const result = applyManualTrackingToCheckoutUrl(url, { trafficSource: null });
+    const parsed = new URL(result);
+
+    expect(parsed.searchParams.get('rb_manual')).toBe('email');
+    expect(parsed.searchParams.get('utm_source')).toBe('manual-email');
+    expect(parsed.searchParams.get('utm_medium')).toBe('email');
+    expect(parsed.searchParams.get('utm_campaign')).toBe('manual-reminder');
+    expect(parsed.searchParams.get('foo')).toBe('bar');
+  });
+
+  it('mantém utms existentes e preserva a fonte paga', () => {
+    const url = 'https://pay.example.com/checkout?utm_source=tiktok&utm_medium=paid';
+
+    const result = applyManualTrackingToCheckoutUrl(url, { trafficSource: 'tiktok.paid' });
+    const parsed = new URL(result);
+
+    expect(parsed.searchParams.get('utm_source')).toBe('tiktok');
+    expect(parsed.searchParams.get('utm_medium')).toBe('paid');
+    expect(parsed.searchParams.get('utm_campaign')).toBe('manual-reminder');
+    expect(parsed.searchParams.get('rb_manual')).toBe('email');
+  });
+
+  it('infere canal pago da origem quando não há medium configurado', () => {
+    const url = 'https://pay.example.com/checkout';
+
+    const result = applyManualTrackingToCheckoutUrl(url, { trafficSource: 'facebook.paid' });
+    const parsed = new URL(result);
+
+    expect(parsed.searchParams.get('utm_source')).toBe('facebook');
+    expect(parsed.searchParams.get('utm_medium')).toBe('paid');
+    expect(parsed.searchParams.get('rb_manual')).toBe('email');
+  });
+});

--- a/lib/checkout.ts
+++ b/lib/checkout.ts
@@ -1,4 +1,26 @@
 const COUPON_PARAMS = ['coupon', 'cupom', 'discount_code', 'discount'];
+const MANUAL_TRACKING_PARAM = 'rb_manual';
+const MANUAL_TRACKING_VALUE = 'email';
+const DEFAULT_ORGANIC_SOURCE = 'manual-email';
+const DEFAULT_ORGANIC_MEDIUM = 'email';
+const DEFAULT_MANUAL_CAMPAIGN = 'manual-reminder';
+const PAID_HINTS = [
+  'paid',
+  'ads',
+  'pago',
+  'trafego',
+  'tráfego',
+  'midia paga',
+  'midiapaga',
+  'cpc',
+  'cpa',
+  'cpp',
+  'cpm',
+  'ppc',
+  'display',
+  'remarketing',
+  'retargeting',
+];
 
 function normalize(value?: string | null) {
   return typeof value === 'string' ? value.trim() : '';
@@ -33,5 +55,94 @@ export function applyDiscountToCheckoutUrl(
   } catch {
     const separator = url.includes('?') ? '&' : '?';
     return `${url}${separator}coupon=${encodeURIComponent(code)}`;
+  }
+}
+
+function getParamCaseInsensitive(params: URLSearchParams, key: string): string | null {
+  const lower = key.toLowerCase();
+  for (const existingKey of params.keys()) {
+    if (existingKey.toLowerCase() === lower) {
+      const value = params.get(existingKey);
+      if (value !== null) {
+        return value;
+      }
+    }
+  }
+  return null;
+}
+
+function detectPaidTrafficHint(value: string | null | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return false;
+  return PAID_HINTS.some((hint) => normalized.includes(hint));
+}
+
+function detectPaidTraffic(
+  medium: string | null,
+  trafficSource: string | null | undefined,
+): boolean {
+  if (detectPaidTrafficHint(medium)) {
+    return true;
+  }
+
+  if (detectPaidTrafficHint(trafficSource)) {
+    return true;
+  }
+
+  return false;
+}
+
+function extractChannelFromTrafficSource(trafficSource: string | null | undefined): string | null {
+  if (typeof trafficSource !== 'string') return null;
+  const trimmed = trafficSource.trim().toLowerCase();
+  if (!trimmed || trimmed === 'unknown') return null;
+  const [first] = trimmed.split(/[./\-|>]/);
+  if (!first) return null;
+  return first;
+}
+
+type ManualTrackingOptions = {
+  trafficSource?: string | null;
+};
+
+export function applyManualTrackingToCheckoutUrl(
+  checkoutUrl?: string | null,
+  options?: ManualTrackingOptions,
+): string {
+  const url = normalize(checkoutUrl);
+  if (!url) return '';
+
+  try {
+    const parsed = new URL(url);
+    const params = parsed.searchParams;
+
+    params.set(MANUAL_TRACKING_PARAM, MANUAL_TRACKING_VALUE);
+
+    const existingMedium = getParamCaseInsensitive(params, 'utm_medium');
+    const existingSource = getParamCaseInsensitive(params, 'utm_source');
+    const existingCampaign = getParamCaseInsensitive(params, 'utm_campaign');
+
+    const isPaidTraffic = detectPaidTraffic(existingMedium, options?.trafficSource ?? null);
+
+    if (!existingSource) {
+      const inferredChannel = isPaidTraffic
+        ? extractChannelFromTrafficSource(options?.trafficSource ?? null)
+        : null;
+      params.set('utm_source', inferredChannel ?? DEFAULT_ORGANIC_SOURCE);
+    }
+
+    if (!existingMedium) {
+      params.set('utm_medium', isPaidTraffic ? 'paid' : DEFAULT_ORGANIC_MEDIUM);
+    }
+
+    if (!existingCampaign) {
+      params.set('utm_campaign', DEFAULT_MANUAL_CAMPAIGN);
+    }
+
+    return parsed.toString();
+  } catch {
+    const separator = url.includes('?') ? '&' : '?';
+    return `${url}${separator}${MANUAL_TRACKING_PARAM}=${encodeURIComponent(MANUAL_TRACKING_VALUE)}`;
   }
 }


### PR DESCRIPTION
## Summary
- add a webhook unit test to ensure manual reminders keep TikTok organic traffic when suffixing with .email

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3eb8d93048332a2bfc6e02a148851