### PR TITLE
Restore test page content with auth layout

### DIFF
--- a/app/test/layout.tsx
+++ b/app/test/layout.tsx
@@ -1,0 +1,14 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { ReactNode } from 'react';
+
+export default function TestLayout({ children }: { children: ReactNode }) {
+  const adminToken = process.env.ADMIN_TOKEN;
+  const token = cookies().get('admin_token')?.value;
+
+  if (!adminToken || token !== adminToken) {
+    redirect('/login');
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
- restore the manual test page UI to its original client component layout
- enforce the admin cookie check for /test via a new server layout wrapper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3fde6ab0483328a6b2b43a6eabf49