### PR TITLE
Ajusta origem manual para classificar e mostrar canal

### DIFF
--- a/app/api/kiwify/webhook/route.test.ts
+++ b/app/api/kiwify/webhook/route.test.ts
@@ -22,6 +22,24 @@ describe('extractTrafficSource - manual reminders', () => {
     expect(result).toBe('tiktok.paid.email');
   });
 
+  it('adiciona o marcador pago quando o histórico só contém o canal', () => {
+    const checkoutUrl =
+      `${baseCheckout}?rb_manual=email&utm_source=tiktok&utm_medium=paid&utm_campaign=manual-reminder`;
+
+    const result = extractTrafficSource({}, checkoutUrl, 'tiktok');
+
+    expect(result).toBe('tiktok.paid.email');
+  });
+
+  it('padroniza lembretes orgânicos preservando o canal existente', () => {
+    const checkoutUrl =
+      `${baseCheckout}?rb_manual=email&utm_source=manual-email&utm_medium=email&utm_campaign=manual-reminder`;
+
+    const result = extractTrafficSource({}, checkoutUrl, 'tiktok');
+
+    expect(result).toBe('tiktok.organic.email');
+  });
+
   it('mantém o canal orgânico quando o manual vem de um tiktok orgânico', () => {
     const checkoutUrl =
       `${baseCheckout}?rb_manual=email&utm_source=manual-email&utm_medium=email&utm_campaign=manual-reminder`;

--- a/app/api/kiwify/webhook/traffic.ts
+++ b/app/api/kiwify/webhook/traffic.ts
@@ -683,8 +683,17 @@ export function extractTrafficSource(
           .filter((part) => part && part !== 'email')
       : [];
 
+    const hasClassification = baseParts.some((part) => part === 'paid' || part === 'organic');
+    const normalizedClassification = normalizeCandidate(classification);
+    const classificationToken =
+      normalizedClassification && (normalizedClassification === 'paid' || normalizedClassification === 'organic')
+        ? normalizedClassification
+        : null;
+
     if (!baseParts.length) {
-      baseParts.push('organic');
+      baseParts.push(classificationToken ?? 'organic');
+    } else if (!hasClassification) {
+      baseParts.push(classificationToken ?? 'organic');
     }
 
     const manualSource = joinTrafficParts([...baseParts, 'email']);

--- a/components/AdsTable.tsx
+++ b/components/AdsTable.tsx
@@ -4,11 +4,7 @@ import { useMemo } from 'react';
 import Table from './Table';
 import Badge from './Badge';
 import { formatSaoPaulo } from '../lib/dates';
-import {
-  getTrafficCategory,
-  getTrafficCategoryLabel,
-  getOrganicPlatformDetail,
-} from '../lib/traffic';
+import { formatTrafficSourceLabel } from '../lib/traffic';
 import { type AdPerformance, type AdMetricValue } from '../lib/ads';
 import type { ReactNode } from 'react';
 
@@ -30,29 +26,6 @@ function formatMetric(metric: AdMetricValue): ReactNode {
       {metric.estimated ? <Badge variant="pending">Estimado</Badge> : null}
     </span>
   );
-}
-
-function formatTrafficSource(source: string | null): string {
-  const trimmed = typeof source === 'string' ? source.trim() : '';
-  if (!trimmed || trimmed.toLowerCase() === 'unknown') {
-    return 'Outros canais';
-  }
-
-  const category = getTrafficCategory(trimmed);
-
-  if (category === 'organic') {
-    const platformDetail = getOrganicPlatformDetail(trimmed);
-    if (platformDetail) {
-      return `${getTrafficCategoryLabel(category)} / ${platformDetail}`;
-    }
-    return getTrafficCategoryLabel(category);
-  }
-
-  if (category === 'tiktok') {
-    return getTrafficCategoryLabel(category);
-  }
-
-  return trimmed;
 }
 
 function formatConversionRate(value: number | null): string {
@@ -86,7 +59,7 @@ export default function AdsTable({ ads }: AdsTableProps) {
       {
         key: 'trafficSource' as const,
         header: 'Canal',
-        render: (ad: AdPerformance) => formatTrafficSource(ad.trafficSource),
+        render: (ad: AdPerformance) => formatTrafficSourceLabel(ad.trafficSource),
       },
       {
         key: 'adClicks' as const,

--- a/components/SalesTable.tsx
+++ b/components/SalesTable.tsx
@@ -6,12 +6,7 @@ import Table from './Table';
 import Badge from './Badge';
 import { formatSaoPaulo } from '../lib/dates';
 import type { Sale } from '../lib/types';
-import {
-  getTrafficCategory,
-  getTrafficCategoryLabel,
-  getOrganicPlatformDetail,
-  type TrafficCategory,
-} from '../lib/traffic';
+import { getTrafficCategory, type TrafficCategory, formatTrafficSourceLabel } from '../lib/traffic';
 
 type FilterKey = 'all' | TrafficCategory;
 
@@ -25,31 +20,6 @@ const FILTERS: { key: FilterKey; label: string }[] = [
 type SalesTableProps = {
   sales: Sale[];
 };
-
-function formatTrafficSource(source: string | null): string {
-  const trimmed = typeof source === 'string' ? source.trim() : '';
-  if (!trimmed || trimmed.toLowerCase() === 'unknown') {
-    return 'Outros canais';
-  }
-
-  const category = getTrafficCategory(trimmed);
-
-  if (category === 'organic') {
-    const platformDetail = getOrganicPlatformDetail(trimmed);
-
-    if (platformDetail) {
-      return `${getTrafficCategoryLabel(category)} / ${platformDetail}`;
-    }
-
-    return getTrafficCategoryLabel(category);
-  }
-
-  if (category === 'tiktok') {
-    return getTrafficCategoryLabel(category);
-  }
-
-  return trimmed;
-}
 
 export default function SalesTable({ sales }: SalesTableProps) {
   const [filter, setFilter] = useState<FilterKey>('all');
@@ -98,7 +68,7 @@ export default function SalesTable({ sales }: SalesTableProps) {
       {
         key: 'traffic_source' as const,
         header: 'Origem',
-        render: (sale: Sale) => formatTrafficSource(sale.traffic_source),
+        render: (sale: Sale) => formatTrafficSourceLabel(sale.traffic_source),
       },
       {
         key: 'paid_at' as const,

--- a/lib/traffic.test.ts
+++ b/lib/traffic.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getTrafficCategory } from './traffic';
+import { formatTrafficSourceLabel, getTrafficCategory } from './traffic';
 
 describe('getTrafficCategory', () => {
   it('classifica tiktok puro como orgânico', () => {
@@ -17,5 +17,20 @@ describe('getTrafficCategory', () => {
 
   it('mantém tiktok organic como orgânico', () => {
     expect(getTrafficCategory('tiktok organic')).toBe('organic');
+  });
+});
+
+describe('formatTrafficSourceLabel', () => {
+  it('exibe classificação orgânica, canal e email', () => {
+    expect(formatTrafficSourceLabel('tiktok.organic.email')).toBe('Orgânico / TikTok / Email');
+  });
+
+  it('exibe canal pago com email', () => {
+    expect(formatTrafficSourceLabel('tiktok.paid.email')).toBe('Pago / TikTok / Email');
+  });
+
+  it('retorna fallback para origens desconhecidas', () => {
+    expect(formatTrafficSourceLabel(null)).toBe('Outros canais');
+    expect(formatTrafficSourceLabel('unknown')).toBe('Outros canais');
   });
 });

--- a/lib/traffic.ts
+++ b/lib/traffic.ts
@@ -9,6 +9,36 @@ const ORGANIC_PLATFORM_KEYWORDS: { keyword: string; label: string }[] = [
   { keyword: 'instagram', label: 'Instagram' },
 ];
 
+type TrafficTokenMetadata = {
+  label: string;
+  priority: number;
+};
+
+const TRAFFIC_TOKEN_METADATA: Record<string, TrafficTokenMetadata> = {
+  organic: { label: 'Orgânico', priority: 0 },
+  org: { label: 'Orgânico', priority: 0 },
+  paid: { label: 'Pago', priority: 0 },
+  pag: { label: 'Pago', priority: 0 },
+  email: { label: 'Email', priority: 2 },
+  'manual-email': { label: 'Email Manual', priority: 2 },
+  manual: { label: 'Manual', priority: 2 },
+  referral: { label: 'Indicação', priority: 1 },
+  social: { label: 'Social', priority: 1 },
+  tiktok: { label: 'TikTok', priority: 1 },
+  facebook: { label: 'Facebook', priority: 1 },
+  instagram: { label: 'Instagram', priority: 1 },
+  google: { label: 'Google', priority: 1 },
+  bing: { label: 'Bing', priority: 1 },
+  taboola: { label: 'Taboola', priority: 1 },
+  kwai: { label: 'Kwai', priority: 1 },
+  pinterest: { label: 'Pinterest', priority: 1 },
+  snapchat: { label: 'Snapchat', priority: 1 },
+  twitter: { label: 'Twitter', priority: 1 },
+  linkedin: { label: 'LinkedIn', priority: 1 },
+  youtube: { label: 'YouTube', priority: 1 },
+  whatsapp: { label: 'WhatsApp', priority: 1 },
+};
+
 export function getTrafficCategory(source: string | null | undefined): TrafficCategory {
   if (!source) {
     return 'other';
@@ -118,4 +148,61 @@ export function getOrganicPlatformDetail(source: string | null | undefined): str
   }
 
   return null;
+}
+
+export function formatTrafficSourceLabel(source: string | null | undefined): string {
+  const trimmed = typeof source === 'string' ? source.trim() : '';
+
+  if (!trimmed || trimmed.toLowerCase() === 'unknown') {
+    return 'Outros canais';
+  }
+
+  const segments = trimmed
+    .split('.')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+
+  const seen = new Set<string>();
+  const entries: Array<{ label: string; priority: number; index: number }> = [];
+
+  const addSegment = (raw: string, index: number) => {
+    const normalized = raw.trim().toLowerCase();
+    if (!normalized || normalized === 'unknown' || seen.has(normalized)) {
+      return;
+    }
+
+    const metadata = TRAFFIC_TOKEN_METADATA[normalized];
+    if (metadata) {
+      entries.push({ label: metadata.label, priority: metadata.priority, index });
+      seen.add(normalized);
+      return;
+    }
+
+    const label = formatPlatformLabel(raw);
+    if (label) {
+      entries.push({ label, priority: 1, index });
+      seen.add(normalized);
+    }
+  };
+
+  segments.forEach((segment, index) => addSegment(segment, index));
+
+  if (!entries.length) {
+    const fallback = formatPlatformLabel(trimmed);
+    if (fallback) {
+      return fallback;
+    }
+
+    return trimmed;
+  }
+
+  entries.sort((a, b) => {
+    if (a.priority !== b.priority) {
+      return a.priority - b.priority;
+    }
+
+    return a.index - b.index;
+  });
+
+  return entries.map((entry) => entry.label).join(' / ');
 }


### PR DESCRIPTION
## Summary
- garante que lembretes manuais preencham o marcador de tráfego pago ou orgânico ao anexar o sufixo .email
- padroniza a formatação da origem nas tabelas usando um helper compartilhado que exibe canal, classificação e email
- cobre os novos comportamentos com testes unitários adicionais

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d407f653148332a85652239dea99a4