### PR TITLE
Add clientes navigation link and improve conversion labeling

### DIFF
--- a/app/clientes/page.tsx
+++ b/app/clientes/page.tsx
@@ -27,13 +27,17 @@ const formatPaidAt = (sale: Sale): { label: string; timestamp: number } => {
   return { label: formatter.format(paidDate), timestamp: paidDate.getTime() };
 };
 
+const DIRECT_PURCHASE_SOURCE = 'kiwify.webhook_purchase';
+
 const getConversionLabel = (sale: Sale): string => {
+  const source = sale.source?.toLowerCase() ?? '';
   const status = sale.status?.toLowerCase() ?? '';
-  if (status.includes('convert')) {
+
+  if (source !== DIRECT_PURCHASE_SOURCE && status.includes('convert')) {
     return 'Carrinho recuperado';
   }
 
-  return 'Compra direta';
+  return 'Aprovado direto';
 };
 
 type ClientPurchase = {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -32,6 +32,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   </Link>
                 </li>
                 <li>
+                  <Link href="/clientes" className="transition hover:text-white">
+                    Clientes
+                  </Link>
+                </li>
+                <li>
                   <Link href="/ads" className="transition hover:text-white">
                     Gestão de Ads
                   </Link>

--- a/lib/sales.ts
+++ b/lib/sales.ts
@@ -185,6 +185,7 @@ export async function fetchApprovedSales(): Promise<Sale[]> {
         status: statusFromRow || statusFromPayload || (paid ? 'converted' : null),
         paid_at: paidAt ?? null,
         traffic_source: clean(row.traffic_source) || trafficFromPayload || null,
+        source: clean(row.source) || null,
       } satisfies Sale;
     });
   } catch (error) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -26,4 +26,5 @@ export type Sale = {
   status: string | null;
   paid_at: string | null;
   traffic_source: string | null;
+  source: string | null;
 };


### PR DESCRIPTION
## Summary
- add the Clientes link to the main navigation header
- extend sales fetching to surface the Supabase source metadata
- classify direct purchases as "Aprovado direto" on the Clientes page while keeping recovered carts labeled properly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d45fa8fe6883329a53022462106667